### PR TITLE
remove parameter i in prototype function of loadItem,and New method _getSize of prototype

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,7 +47,7 @@
          || rect.left < 0 && (rect.left + rect.width >= Lazyload.DISTANCE))
         && rect.top <= (window.innerHeight || document.documentElement.clientHeight)
         && rect.left <= (window.innerWidth || document.documentElement.clientWidth)) {
-        this.loadItem(ele, i);
+        this.loadItem(ele);
         this.elements.splice(i, 1);
         i--; len--;
       }
@@ -55,7 +55,7 @@
   };
 
   // lazyload img or script
-  Lazyload.prototype.loadItem = function(ele, i) {
+  Lazyload.prototype.loadItem = function(ele) {
     var imgs = ele.getElementsByTagName("img");
     for(var i = 0, len = imgs.length; i < len; i++) {
       var img = imgs[i];

--- a/index.js
+++ b/index.js
@@ -42,7 +42,9 @@
     for (var i = 0, len = this.elements.length; i < len; i++) {
       var ele = this.elements[i];
       var rect = ele.getBoundingClientRect();
-      if(rect.top >= Lazyload.DISTANCE && rect.left >= Lazyload.DISTANCE
+      if((rect.top >= Lazyload.DISTANCE && rect.left >= Lazyload.DISTANCE
+         || rect.top < 0 && (rect.top + rect.height) >= Lazyload.DISTANCE
+         || rect.left < 0 && (rect.left + rect.width >= Lazyload.DISTANCE))
         && rect.top <= (window.innerHeight || document.documentElement.clientHeight)
         && rect.left <= (window.innerWidth || document.documentElement.clientWidth)) {
         this.loadItem(ele, i);

--- a/index.js
+++ b/index.js
@@ -20,6 +20,7 @@
 
   // init, bind event
   Lazyload.prototype.init = function() {
+	this._getSize();
     var self = this;
     self._detectElementIfInScreen();
 
@@ -31,10 +32,17 @@
       }, 50);
     });
     addEventListener("resize", function(){
+	  self._getSize();
       timer && clearTimeout(timer);
       self._detectElementIfInScreen();
     });
   };
+  
+  // get screen size
+  Lazyload.prototype._getSize = function() { 
+	this.screenHeight = window.innerHeight || document.documentElement.clientHeight; //browser height
+	this.screenWidth = window.innerWidth || document.documentElement.clientWidth; //browser width
+  };  
 
   // detect if in screen
   Lazyload.prototype._detectElementIfInScreen = function() {
@@ -45,8 +53,7 @@
       if((rect.top >= Lazyload.DISTANCE && rect.left >= Lazyload.DISTANCE
          || rect.top < 0 && (rect.top + rect.height) >= Lazyload.DISTANCE
          || rect.left < 0 && (rect.left + rect.width >= Lazyload.DISTANCE))
-        && rect.top <= (window.innerHeight || document.documentElement.clientHeight)
-        && rect.left <= (window.innerWidth || document.documentElement.clientWidth)) {
+        && rect.top <= this.screenHeight && rect.left <= this.screenWidth) {
         this.loadItem(ele);
         this.elements.splice(i, 1);
         i--; len--;


### PR DESCRIPTION
小胡子哥，您好，
1:当dom元素处于窗口可视区域时，执行lazyload img or script,每次也都是遍历父容器的子元素，没有使用到参数i，请教下，可以修改成直接暴露一个父容器约束，让它更加简洁一些吗？
2:浏览器窗口高度跟宽度,这个应该可以用不同的变量放到循环外面，避开每次都计算这两个尺寸了，当用户缩放浏览器的时候，再实时对窗口尺寸进行更新。
